### PR TITLE
Invite contributors to teams

### DIFF
--- a/text/0000-contributor-team.md
+++ b/text/0000-contributor-team.md
@@ -1,0 +1,39 @@
+- Start Date: 2019-02-27
+- RFC PR:
+- unified Issue:
+
+# Summary
+
+It'd be nice to add a "contributor" team to unified organizations which
+all contributors are invited to. There's precedent here with what Gatsby
+does and helps contributors receive a warm welcome to the community after
+getting a PR merged.
+
+## Basic example
+
+If a user gets a PR merged they receive an invite to the org as a "contributor".
+The contributor team doesn't have write access.
+
+## Motivation
+
+To make contributors feel welcome.
+
+## Detailed design
+
+For now we can manually handle it, but eventually we can use a GitHub Action.
+
+## Drawbacks
+
+None that I can see.
+
+## Alternatives
+
+N/A
+
+## Adoption strategy
+
+N/A
+
+## Unresolved questions
+
+N/A

--- a/text/0000-contributor-team.md
+++ b/text/0000-contributor-team.md
@@ -20,7 +20,9 @@ To make contributors feel welcome.
 
 ## Detailed design
 
-For now we can manually handle it, but eventually we can use a GitHub Action.
+We can use a GitHub Action (once unified orgs have access) to check if the new
+contributor is part of the org and add them if they aren't to the contributor
+team.
 
 ## Drawbacks
 
@@ -28,7 +30,8 @@ None that I can see.
 
 ## Alternatives
 
-N/A
+- GitHub contribution graph
+- [all-contributors](https://github.com/all-contributors/all-contributors)
 
 ## Adoption strategy
 
@@ -36,4 +39,4 @@ N/A
 
 ## Unresolved questions
 
-N/A
+- What (if any) access do read-only members have to GitHub integrated platforms? (Zeit Now, Travis CI, etc)

--- a/text/0000-contributor-team.md
+++ b/text/0000-contributor-team.md
@@ -1,18 +1,18 @@
 - Start Date: 2019-02-27
-- RFC PR:
+- RFC PR: [2][]
 - unified Issue:
 
 # Summary
 
-It'd be nice to add a "contributor" team to unified organizations which
-all contributors are invited to. There's precedent here with what Gatsby
-does and helps contributors receive a warm welcome to the community after
-getting a PR merged.
+It'd be nice to add a “contributor” team to unified organizations which
+all contributors are invited to.
+There’s precedent here with what Gatsby does and helps contributors
+receive a warm welcome to the community after getting a PR merged.
 
 ## Basic example
 
-If a user gets a PR merged they receive an invite to the org as a "contributor".
-The contributor team doesn't have write access.
+If a user gets a PR merged they receive an invite to the org as a “contributor”.
+The contributor team has triage (not write) access on GitHub.
 
 ## Motivation
 
@@ -20,18 +20,17 @@ To make contributors feel welcome.
 
 ## Detailed design
 
-We can use a GitHub Action (once unified orgs have access) to check if the new
-contributor is part of the org and add them if they aren't to the contributor
-team.
+*   [Motion to nominate a contributor][motion]
+*   [`github-tools`][tools]
 
 ## Drawbacks
 
-None that I can see.
+*   Could grow into 100s of inactive contributors
 
 ## Alternatives
 
-- GitHub contribution graph
-- [all-contributors](https://github.com/all-contributors/all-contributors)
+*   GitHub contribution graph
+*   [`all-contributors`][all-contributors]
 
 ## Adoption strategy
 
@@ -39,4 +38,12 @@ N/A
 
 ## Unresolved questions
 
-- What (if any) access do read-only members have to GitHub integrated platforms? (Zeit Now, Travis CI, etc)
+N/A
+
+[2]: https://github.com/unifiedjs/rfcs/pull/2
+
+[motion]: https://github.com/unifiedjs/governance/blob/master/members.md#motion-to-nominate-a-contributor
+
+[tools]: https://github.com/unifiedjs/github-tools
+
+[all-contributors]: https://github.com/all-contributors/all-contributors


### PR DESCRIPTION
It'd be nice to add a "contributor" team to unified organizations which all contributors are invited to. There's precedent here with what Gatsby does and helps contributors receive a warm welcome to the community after getting a PR merged.

---

[_Rendered version_](https://github.com/unifiedjs/rfcs/blob/contributor-team/text/0000-contributor-team.md)